### PR TITLE
base saving corrected

### DIFF
--- a/app/chessbase/base-manager.js
+++ b/app/chessbase/base-manager.js
@@ -11,11 +11,14 @@ var filename = 'base.json';
 module.exports.getFen = ({ fen, depth }) => {
   return bestmovedb.getFen({ fen, depth });
 };
-
+let savePromise = Promise.resolve();
 module.exports.saveBase = function() {
-  fs.writeFile(filename, baseSerializer.stringify(base, true), err => {
-    if (err) console.error(err);
+  savePromise = savePromise.finally(() => {
+    fs.writeFile(filename, baseSerializer.stringify(base, true), err => {
+      if (err) console.error(err);
+    });
   });
+  return savePromise;
 };
 
 var createChildPositionObject = function(parentObject, childMove, isBest) {
@@ -63,8 +66,8 @@ module.exports.addToJsonBase = function(moves, bestAnswer, scoreValue, depth) {
       positionObject = createChildPositionObject(parent, moves[i]);
     }
   }
-  improveEvaluation(positionObject, evaluationObject);
-  if (positionObject !== null) {
+  if(!positionObject.e || positionObject.e.d <= evaluationObject.d) {
+    improveEvaluation(positionObject, evaluationObject);
     parent = positionObject;
     var index;
     var subPositionObject = (function() {

--- a/spec/chessbase/base-manager-spec.js
+++ b/spec/chessbase/base-manager-spec.js
@@ -56,6 +56,12 @@ describe('baseManager', () => {
       baseManager.addToBase([], 'd4', 0.1, 39);
       expect(base.s[0].e).toEqual({v: 0.11, d: 40});
     });
+    it('does not change the best answer if evalution has lower depth', () => {
+      base.e = {v:0.11, d:45};
+      base.s = [{m: 'e4', e: {}}];
+      baseManager.addToBase([], 'd4', 0.1, 44);
+      expect(base.s[0].m).toEqual('e4');
+    });
     it('adds position to bestmovedb', () => {
       spyOn(bestmovedb, 'add').and.stub();
       baseManager.addToBase([], 'd4', 0.1, 100);
@@ -96,18 +102,18 @@ describe('baseManager', () => {
     });
   });
   describe('saveBase', () => {
-    it('save to base.json', function() {      
+    it('save to base.json', async function() {
       spyOn(fs, 'writeFile').and.stub();
       delete base.e;
       delete base.s;
-      baseManager.saveBase();
+      await baseManager.saveBase();
       expect(fs.writeFile).toHaveBeenCalledWith('base.json', '{"m": "", "n": 0, "c": "b", "t": "wb", "s": []}', jasmine.anything());
     });
-    it('console.error is called in case of error during writeFile', () => {
+    it('console.error is called in case of error during writeFile', async () => {
       spyOn(fs, 'writeFile').and.callFake((file, data, callback) => {callback('error');});
       spyOn(console, 'error').and.callThrough();
 
-      baseManager.saveBase();
+      await baseManager.saveBase();
 
       expect(console.error).toHaveBeenCalledWith('error');
     });


### PR DESCRIPTION
2 issues are addressed:
- correct saving base during simultanious requests (promise chaining added)
- best answer is saved only if evaluation depth is greater than existent
